### PR TITLE
feat(config): Setting default config directory using env NVRS_CONFIG_DIR

### DIFF
--- a/book/src/configuration.md
+++ b/book/src/configuration.md
@@ -1,5 +1,7 @@
 # configuration
 nvrs relies on a TOML configuration file ([example](https://github.com/adamperkowski/nvrs/blob/main/nvrs.toml)) containing basic settings, such as `oldver`, `newver` & `keyfile` paths, as well as [package entries](/package-entries.md). supported config paths:
-- `$XDG_CONFIG_HOME/nvrs.toml` (`~/.config/nvrs.toml` if the variable is not set)
 - `./nvrs.toml`
+- `$NVRS_CONFIG_DIR/nvrs.toml`
+- `$XDG_CONFIG_HOME/nvrs/nvrs.toml` (`$HOME/.config/nvrs/nvrs.toml` if the variable is not set)
+- `$HOME/.config/nvrs.toml`
 - custom paths set with `nvrs --config`

--- a/src/config.rs
+++ b/src/config.rs
@@ -203,9 +203,15 @@ pub async fn load(custom_path: &Option<String>) -> error::Result<(Config, PathBu
         }
     } else {
         let default_path = Path::new("nvrs.toml");
+        let config_env_nvrs = match env::var("NVRS_CONFIG_DIR") {
+            Ok(s) => Ok(expand_tilde(s)?),
+            Err(e) => Err(e),
+        };
         let config_home = format!(
-            "{}/nvrs/nvrs.toml",
-            env::var("XDG_CONFIG_HOME").unwrap_or(expand_tilde("~/.config".to_string())?)
+            "{}/nvrs.toml",
+            config_env_nvrs
+                .or_else(|_| env::var("XDG_CONFIG_HOME").map(|v| format!("{}/nvrs", v)))
+                .unwrap_or(expand_tilde("~/.config/nvrs".to_string())?)
         );
         let config_home_non_xdg = expand_tilde("~/.config/nvrs.toml".to_string())?;
         let config_home_non_xdg = Path::new(&config_home_non_xdg);

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,7 +8,7 @@ use colored::Colorize;
 const RATE_LIMIT: &str = "we might be getting rate-limited here";
 const CONFIG_PATHS: &str = "config file locations:
  ./nvrs.toml
- $NVRS_CONFIG_DIR/nvrs/nvrs.toml
+ $NVRS_CONFIG_DIR/nvrs.toml
  $XDG_CONFIG_HOME/nvrs/nvrs.toml
  $HOME/.config/nvrs.toml";
 const NOT_EMPTY: &str = "make sure the file is not empty";

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,6 +8,7 @@ use colored::Colorize;
 const RATE_LIMIT: &str = "we might be getting rate-limited here";
 const CONFIG_PATHS: &str = "config file locations:
  ./nvrs.toml
+ $NVRS_CONFIG_DIR/nvrs/nvrs.toml
  $XDG_CONFIG_HOME/nvrs/nvrs.toml
  $HOME/.config/nvrs.toml";
 const NOT_EMPTY: &str = "make sure the file is not empty";


### PR DESCRIPTION
# Using environment variable to set default config location #41 

## Description
Using env NVRS_CONFIG_DIR to set default config director
Precedence order is
- custom location defined via --config
- NVRS_CONFIG_DIR
- XDG_CONFIG_HOME
- ~/.config/nvrs

## Context

- Resolves #41  

## Testing

## Screenshots / Logs (if applicable)

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I made corresponding changes to the documentation.
- [x] I formatted the code with [rustfmt](https://github.com/rust-lang/rustfmt).
- [x] I checked the lints with [clippy](https://github.com/rust-lang/rust-clippy).